### PR TITLE
Update argument-captor.md

### DIFF
--- a/content/docs/mockito-migrate/argument-captor.md
+++ b/content/docs/mockito-migrate/argument-captor.md
@@ -37,7 +37,7 @@ It turns out that there is an even simpler way to run assertions on an argument 
 ```kotlin
 every {
   mockPhone.call(withArg { person ->
-    assertEquals("Sarah Jane", person.captured.name)
+    assertEquals("Sarah Jane", person.name)
   })
 } returns Unit
 ```


### PR DESCRIPTION
In the Inline assertions example, `person` is not `CapturingSlot` type, so it doesn't have `captured` function. Should use `person.name` instead.