### PR TITLE
Add new keyword in Java snippet for static mocking example

### DIFF
--- a/content/docs/mocking/static.md
+++ b/content/docs/mocking/static.md
@@ -59,7 +59,7 @@ package com.name.app;
 
 class Writer {
   public static File getFile(String path) {
-    return File(path);
+    return new File(path);
   }
 }
 ```


### PR DESCRIPTION
I believe that the `new` keyword was missed here due to Kotlin/Java snippets interchange. 
It got my attention while completing the guidebook and made me pause for some seconds, so I think it would help if corrected.